### PR TITLE
Improve citation accessibility

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,13 @@
+cff-version: 1.2.0
+message: "The dataset is for academic use only. Commercial use is prohibited. If you use this dataset in your research please cite it accordingly."
+authors:
+- family-names: "Schleiss"
+  given-names: "Michael"
+- family-names: "Rouatbi"
+  given-names: "Fami"
+- family-names: "Cremers"
+  given-names: "Daniel"
+title: "VPAIR-Aerial Visual Place Recognition and Localization in Large-scale Outdoor Environments"
+version: 1.0.0
+date-released: 2022-06-27
+url: "https://github.com/AerVisLoc/vpair"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,3 +11,16 @@ title: "VPAIR-Aerial Visual Place Recognition and Localization in Large-scale Ou
 version: 1.0.0
 date-released: 2022-06-27
 url: "https://github.com/AerVisLoc/vpair"
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Schleiss"
+    given-names: "Michael"
+  - family-names: "Rouatbi"
+    given-names: "Fami"
+  - family-names: "Cremers"
+    given-names: "Daniel"
+  journal: "arXiv preprint arXiv:2205.11567"
+  month: 5
+  title: "VPAIR-Aerial Visual Place Recognition and Localization in Large-scale Outdoor Environments"
+  year: 2022

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ To request full access to the dataset please fill out the following form ([Link]
 
 The dataset is for academic use only. Commercial use is prohibited. If you use this dataset in your research please cite it accordingly:
 
-```@article{schleiss2022vpair,
+```
+@article{schleiss2022vpair,
   title={VPAIR-Aerial Visual Place Recognition and Localization in Large-scale Outdoor Environments},
   author={Schleiss, Michael and Rouatbi, Fahmi and Cremers, Daniel},
   journal={arXiv preprint arXiv:2205.11567},


### PR DESCRIPTION
The markdown for the citation in the README was a little broken, since the `@article` is interpreted as codeblock language when it is placed directly on the fence. I've also added a CITATION.cff which adds this nice UI for simple citing:

![image](https://user-images.githubusercontent.com/18090140/202383112-8b38f175-d206-46ee-a640-a6fd5ed46f9d.png)
